### PR TITLE
feat: bootstrap the skills repo with loong-monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# skills
-Public skills collection for the LoongClaw team, including LoongClaw-related skills and internally developed skills.
+# LoongClaw Skills
+
+Public skills collection for the LoongClaw team.
+
+This repository stores reusable skills that are either:
+
+- directly related to the `loongclaw-ai/loongclaw` project and adjacent tooling
+- created by the LoongClaw team for recurring engineering, analysis, and delivery workflows
+
+## Repository Layout
+
+```text
+skills/
+└── <skill-name>/
+    ├── SKILL.md
+    ├── agents/openai.yaml
+    ├── scripts/
+    ├── references/
+    └── assets/
+```
+
+Each skill should stay self-contained. Keep the procedural guidance in `SKILL.md`, store reusable code in `scripts/`, put detailed analysis frameworks or reference docs in `references/`, and keep output templates in `assets/`.
+
+## Skills
+
+See [skills/README.md](/Users/chum/skills/skills/README.md) for the catalog.
+
+## Current Focus
+
+The first skill in this repository is `loong-monitor`, which analyzes recent GitHub activity in `loongclaw-ai/loongclaw` and helps produce evidence-backed status and direction reports.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,16 @@
+# Skill Catalog
+
+This directory contains the team-maintained skill catalog for LoongClaw.
+
+## Available Skills
+
+| Skill | Purpose |
+| --- | --- |
+| `loong-monitor` | Analyze recent PR and issue activity in `loongclaw-ai/loongclaw`, summarize current focus areas, assess project status, and infer likely next directions. |
+
+## Conventions
+
+- Use lowercase hyphenated folder names.
+- Keep each skill self-contained inside its own directory.
+- Put reusable automation in `scripts/` rather than embedding long code snippets inside `SKILL.md`.
+- Keep factual evidence and analytical heuristics separate: raw collection belongs in scripts, reasoning guidance belongs in `references/`.

--- a/skills/loong-monitor/SKILL.md
+++ b/skills/loong-monitor/SKILL.md
@@ -69,6 +69,13 @@ python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
   --repo loongclaw-ai/loongclaw
 ```
 
+For rolling quarterly reporting:
+
+```bash
+python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
+  --preset quarter
+```
+
 For calendar-aligned reporting:
 
 ```bash
@@ -79,6 +86,12 @@ python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
 ```bash
 python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
   --preset calendar-month \
+  --until 2026-03-31
+```
+
+```bash
+python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
+  --preset calendar-quarter \
   --until 2026-03-31
 ```
 
@@ -112,7 +125,7 @@ Do not treat inferred roadmap direction as confirmed fact unless it is explicitl
 Use [assets/report-template.md](assets/report-template.md) as the output skeleton when the user wants a written report.
 
 Prefer the generated report script when the user asks for a reusable report artifact, a weekly digest, or a compare-the-last-two-windows assessment.
-Prefer the preset runner when the user explicitly wants a weekly report, monthly report, calendar-aligned report, or a repeatable one-command monitoring workflow.
+Prefer the preset runner when the user explicitly wants a weekly report, monthly report, quarterly report, calendar-aligned report, or a repeatable one-command monitoring workflow.
 
 Minimum report structure:
 

--- a/skills/loong-monitor/SKILL.md
+++ b/skills/loong-monitor/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: loong-monitor
+description: Scan recent GitHub activity in loongclaw-ai/loongclaw and related LoongClaw repositories to build evidence-backed reports on recent PRs, issues, current focus areas, project status, risks, and likely next directions. Use this skill for weekly or monthly monitoring, repo health snapshots, delivery reviews, roadmap check-ins, or any request to analyze where LoongClaw work is concentrating and how the project is evolving.
+---
+
+# Loong Monitor
+
+## Overview
+
+This skill turns recent GitHub issue and pull request activity into a concise monitoring report for LoongClaw. It is designed for status reviews, activity scans, roadmap inference, delivery retrospectives, and periodic project health snapshots.
+
+Use it when the user asks questions like:
+
+- "最近 LoongClaw 主要在做什么？"
+- "Scan LoongClaw PRs and issues from the last 30 days."
+- "Summarize the current state of `loongclaw-ai/loongclaw`."
+- "What looks like the next likely direction based on recent activity?"
+- "Generate a weekly report for LoongClaw repo progress."
+
+## Workflow
+
+### 1. Define the monitoring window
+
+Default to the last 30 days unless the user specifies a narrower or wider range.
+
+Capture:
+
+- target repository, usually `loongclaw-ai/loongclaw`
+- time window: `--days`, or explicit `--since` and `--until`
+- whether you need only a summary or a full report artifact
+
+If the request is ambiguous, make a reasonable default and state it.
+
+### 2. Collect evidence first
+
+Run the collector script before writing conclusions:
+
+```bash
+python3 skills/loong-monitor/scripts/collect_repo_activity.py \
+  --repo loongclaw-ai/loongclaw \
+  --days 30 \
+  --output /tmp/loong-monitor
+```
+
+Useful variants:
+
+```bash
+python3 skills/loong-monitor/scripts/collect_repo_activity.py \
+  --repo loongclaw-ai/loongclaw \
+  --since 2026-03-01 \
+  --until 2026-03-31 \
+  --limit 80 \
+  --detail-limit 25 \
+  --output /tmp/loong-monitor-march
+```
+
+The script produces:
+
+- `activity.json`: raw collected issue and PR data plus computed summary signals
+- `summary.md`: a compact evidence digest you can quote and reason over
+
+### 3. Interpret with discipline
+
+Use the collected evidence to separate three layers of conclusions:
+
+1. Facts: counts, merged PRs, open issues, touched paths, comment volume, labels.
+2. Working interpretation: what those signals suggest about current team focus or operational status.
+3. Inference: plausible next directions or emerging themes. Label these clearly as inference.
+
+Do not treat inferred roadmap direction as confirmed fact unless it is explicitly stated in issues, PR descriptions, or linked docs.
+
+### 4. Produce the report
+
+Use [assets/report-template.md](assets/report-template.md) as the output skeleton when the user wants a written report.
+
+Minimum report structure:
+
+- Monitoring window and repo
+- Executive summary
+- Current focus areas
+- Current status and delivery signals
+- Risks, blockers, and unresolved threads
+- Likely next directions
+- Evidence appendix with linked issue and PR references
+
+## Analytical Rules
+
+- Prefer merged PRs when describing delivered work.
+- Prefer open PRs and open issues when describing current queue, risks, or upcoming work.
+- Use touched file paths, labels, and recurring title terms to identify focus areas.
+- Call out uncertainty when the sample size is small or labels are sparse.
+- Cite item numbers and URLs for every non-trivial claim.
+- Avoid overstating momentum from a single noisy PR or issue.
+
+For the full analysis framework and phrasing rules, read [references/analysis-framework.md](references/analysis-framework.md).
+
+## Output Expectations
+
+Good outputs from this skill should answer:
+
+- What changed recently?
+- Where is most engineering attention going?
+- What is currently blocked, active, or stabilizing?
+- What does the recent activity imply about likely next work?
+
+If the evidence is weak, say that directly and explain what data is missing.

--- a/skills/loong-monitor/SKILL.md
+++ b/skills/loong-monitor/SKILL.md
@@ -56,10 +56,25 @@ python3 skills/loong-monitor/scripts/collect_repo_activity.py \
   --output /tmp/loong-monitor-march
 ```
 
+For one-click weekly or monthly reporting, use the preset runner:
+
+```bash
+python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
+  --preset weekly
+```
+
+```bash
+python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
+  --preset monthly \
+  --repo loongclaw-ai/loongclaw
+```
+
 The script produces:
 
 - `activity.json`: raw collected issue and PR data plus computed summary signals
 - `summary.md`: a compact evidence digest you can quote and reason over
+- `report.md`: a full Markdown monitoring report when you use the one-click preset runner
+- `run.txt`: a small manifest showing the exact output paths for the run
 
 When you need a full report, generate it from the collected artifact:
 
@@ -84,6 +99,7 @@ Do not treat inferred roadmap direction as confirmed fact unless it is explicitl
 Use [assets/report-template.md](assets/report-template.md) as the output skeleton when the user wants a written report.
 
 Prefer the generated report script when the user asks for a reusable report artifact, a weekly digest, or a compare-the-last-two-windows assessment.
+Prefer the preset runner when the user explicitly wants a weekly report, monthly report, or a repeatable one-command monitoring workflow.
 
 Minimum report structure:
 

--- a/skills/loong-monitor/SKILL.md
+++ b/skills/loong-monitor/SKILL.md
@@ -27,6 +27,7 @@ Capture:
 
 - target repository, usually `loongclaw-ai/loongclaw`
 - time window: `--days`, or explicit `--since` and `--until`
+- whether you want previous-window comparison enabled
 - whether you need only a summary or a full report artifact
 
 If the request is ambiguous, make a reasonable default and state it.
@@ -39,6 +40,7 @@ Run the collector script before writing conclusions:
 python3 skills/loong-monitor/scripts/collect_repo_activity.py \
   --repo loongclaw-ai/loongclaw \
   --days 30 \
+  --compare-previous \
   --output /tmp/loong-monitor
 ```
 
@@ -59,6 +61,14 @@ The script produces:
 - `activity.json`: raw collected issue and PR data plus computed summary signals
 - `summary.md`: a compact evidence digest you can quote and reason over
 
+When you need a full report, generate it from the collected artifact:
+
+```bash
+python3 skills/loong-monitor/scripts/generate_report.py \
+  --activity /tmp/loong-monitor/activity.json \
+  --output /tmp/loong-monitor/report.md
+```
+
 ### 3. Interpret with discipline
 
 Use the collected evidence to separate three layers of conclusions:
@@ -73,12 +83,15 @@ Do not treat inferred roadmap direction as confirmed fact unless it is explicitl
 
 Use [assets/report-template.md](assets/report-template.md) as the output skeleton when the user wants a written report.
 
+Prefer the generated report script when the user asks for a reusable report artifact, a weekly digest, or a compare-the-last-two-windows assessment.
+
 Minimum report structure:
 
 - Monitoring window and repo
 - Executive summary
 - Current focus areas
 - Current status and delivery signals
+- Comparison to previous window when requested
 - Risks, blockers, and unresolved threads
 - Likely next directions
 - Evidence appendix with linked issue and PR references

--- a/skills/loong-monitor/SKILL.md
+++ b/skills/loong-monitor/SKILL.md
@@ -102,6 +102,20 @@ The script produces:
 - `report.md`: a full Markdown monitoring report when you use the one-click preset runner
 - `run.txt`: a small manifest showing the exact output paths for the run
 
+If the team needs stable artifact locations outside `/tmp`, publish the run to a fixed directory:
+
+```bash
+python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
+  --preset weekly \
+  --copy-to /path/to/team-monitor-reports
+```
+
+This creates:
+
+- `<copy-to>/<repo_slug>/<run-name>/`
+- `<copy-to>/<repo_slug>/latest-<preset>/`
+- `<copy-to>/<repo_slug>/latest/`
+
 When you need a full report, generate it from the collected artifact:
 
 ```bash

--- a/skills/loong-monitor/SKILL.md
+++ b/skills/loong-monitor/SKILL.md
@@ -69,6 +69,19 @@ python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
   --repo loongclaw-ai/loongclaw
 ```
 
+For calendar-aligned reporting:
+
+```bash
+python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
+  --preset calendar-week
+```
+
+```bash
+python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
+  --preset calendar-month \
+  --until 2026-03-31
+```
+
 The script produces:
 
 - `activity.json`: raw collected issue and PR data plus computed summary signals
@@ -99,7 +112,7 @@ Do not treat inferred roadmap direction as confirmed fact unless it is explicitl
 Use [assets/report-template.md](assets/report-template.md) as the output skeleton when the user wants a written report.
 
 Prefer the generated report script when the user asks for a reusable report artifact, a weekly digest, or a compare-the-last-two-windows assessment.
-Prefer the preset runner when the user explicitly wants a weekly report, monthly report, or a repeatable one-command monitoring workflow.
+Prefer the preset runner when the user explicitly wants a weekly report, monthly report, calendar-aligned report, or a repeatable one-command monitoring workflow.
 
 Minimum report structure:
 
@@ -109,6 +122,7 @@ Minimum report structure:
 - Current status and delivery signals
 - Comparison to previous window when requested
 - Risks, blockers, and unresolved threads
+- Confidence and uncertainty level
 - Likely next directions
 - Evidence appendix with linked issue and PR references
 

--- a/skills/loong-monitor/SKILL.md
+++ b/skills/loong-monitor/SKILL.md
@@ -110,11 +110,21 @@ python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
   --copy-to /path/to/team-monitor-reports
 ```
 
+To maintain a Markdown index for published runs:
+
+```bash
+python3 skills/loong-monitor/scripts/run_monitor_cycle.py \
+  --preset weekly \
+  --copy-to /path/to/team-monitor-reports \
+  --index-file /path/to/team-monitor-reports/loongclaw-ai__loongclaw/index.md
+```
+
 This creates:
 
 - `<copy-to>/<repo_slug>/<run-name>/`
 - `<copy-to>/<repo_slug>/latest-<preset>/`
 - `<copy-to>/<repo_slug>/latest/`
+- `<copy-to>/<repo_slug>/index.md` by default, or a custom path when `--index-file` is set
 
 When you need a full report, generate it from the collected artifact:
 

--- a/skills/loong-monitor/agents/openai.yaml
+++ b/skills/loong-monitor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Loong Monitor"
+  short_description: "Analyze LoongClaw GitHub activity trends"
+  default_prompt: "Use $loong-monitor to analyze recent activity in loongclaw-ai/loongclaw and produce a concise status report."

--- a/skills/loong-monitor/assets/report-template.md
+++ b/skills/loong-monitor/assets/report-template.md
@@ -25,6 +25,14 @@ Summarize:
 - open issue pressure
 - signs of stabilization, expansion, or blockage
 
+## Comparison To Previous Window
+
+Optional when comparison data is available:
+
+- current window versus previous window deltas
+- whether throughput is improving or slipping
+- whether new labels, terms, or path clusters are emerging
+
 ## Risks And Open Questions
 
 Call out stalled PRs, unresolved issues, review bottlenecks, or missing follow-through.

--- a/skills/loong-monitor/assets/report-template.md
+++ b/skills/loong-monitor/assets/report-template.md
@@ -3,6 +3,7 @@
 - Repository:
 - Monitoring window:
 - Generated at:
+- Run preset:
 
 ## Executive Summary
 

--- a/skills/loong-monitor/assets/report-template.md
+++ b/skills/loong-monitor/assets/report-template.md
@@ -1,0 +1,41 @@
+# LoongClaw Monitor Report
+
+- Repository:
+- Monitoring window:
+- Generated at:
+
+## Executive Summary
+
+Provide a 3-5 sentence summary of the main activity trend, the current delivery posture, and the most important risk or opportunity.
+
+## Current Focus Areas
+
+List the top 2-4 focus areas with concrete evidence:
+
+- focus area
+- why it appears central in the current window
+- linked issue and PR evidence
+
+## Current Status
+
+Summarize:
+
+- merged PR activity
+- active open PRs
+- open issue pressure
+- signs of stabilization, expansion, or blockage
+
+## Risks And Open Questions
+
+Call out stalled PRs, unresolved issues, review bottlenecks, or missing follow-through.
+
+## Likely Next Directions
+
+Mark this section as inference. Explain what the current activity pattern suggests may happen next.
+
+## Evidence Appendix
+
+- key PRs
+- key issues
+- notable path clusters
+- notable labels or title themes

--- a/skills/loong-monitor/assets/report-template.md
+++ b/skills/loong-monitor/assets/report-template.md
@@ -38,6 +38,14 @@ Optional when comparison data is available:
 
 Call out stalled PRs, unresolved issues, review bottlenecks, or missing follow-through.
 
+## Confidence And Uncertainty
+
+State:
+
+- confidence level: high, medium, or low
+- why the evidence supports that level
+- what the current report cannot confidently infer
+
 ## Likely Next Directions
 
 Mark this section as inference. Explain what the current activity pattern suggests may happen next.

--- a/skills/loong-monitor/references/analysis-framework.md
+++ b/skills/loong-monitor/references/analysis-framework.md
@@ -1,0 +1,80 @@
+# Loong Monitor Analysis Framework
+
+Use this reference after collecting evidence with `scripts/collect_repo_activity.py`.
+
+## Goal
+
+Convert recent issue and PR activity into a defensible monitoring report that distinguishes:
+
+- direct evidence
+- interpretation grounded in evidence
+- forward-looking inference
+
+## Evidence Hierarchy
+
+Use stronger signals first:
+
+1. Merged PRs
+2. Open PRs with active updates or review activity
+3. Open issues with comments or linked implementation
+4. Closed issues without linked code
+5. Labels and title keywords
+
+If stronger signals are unavailable, explicitly downgrade confidence.
+
+## Focus Area Detection
+
+Prefer the following evidence in this order:
+
+1. Repeated path prefixes from changed files in recent PRs
+2. Repeated labels across PRs and issues
+3. Recurring title terms that are specific to the project domain
+4. Clusters of linked issues and PRs around a single feature or subsystem
+
+Good focus-area phrasing:
+
+- "Recent merged PRs concentrate on `crates/kernel` and `docs/`, suggesting active kernel hardening plus architecture documentation work."
+- "Open issues and PRs are clustered around release automation, which indicates current attention on delivery reliability."
+
+Weak phrasing to avoid:
+
+- "The team is definitely pivoting to X."
+- "This proves the roadmap is Y."
+
+## Status Assessment
+
+Assess the project status using these lenses:
+
+- delivery velocity: merged PR count, cadence, and recency
+- queue pressure: number of active open PRs and issues
+- review friction: long-lived PRs, many comments, stalled updates
+- stabilization signals: docs, tests, refactors, cleanup, architecture work
+- expansion signals: new subsystems, new feature threads, exploratory issues
+
+Status labels should be plain and descriptive, for example:
+
+- "active delivery with moderate review queue"
+- "stabilization and hardening phase"
+- "architecture consolidation with limited feature expansion"
+- "exploratory planning with low implementation throughput"
+
+## Next-Direction Inference
+
+Only infer next directions from patterns such as:
+
+- an open PR building directly on recent merged work
+- a cluster of issues around the same subsystem
+- repeated documentation, architecture, or release work that usually precedes a release or consolidation phase
+- unfinished high-comment or high-priority threads
+
+Always mark these statements as inference or likely direction.
+
+## Report Checklist
+
+Before finalizing the report, ensure it includes:
+
+- explicit monitoring window
+- total issue and PR counts for the window
+- at least 3 concrete linked artifacts in the evidence section when available
+- a clear distinction between current facts and future inference
+- a statement of uncertainty if labels, file paths, or sample size are weak

--- a/skills/loong-monitor/references/analysis-framework.md
+++ b/skills/loong-monitor/references/analysis-framework.md
@@ -51,6 +51,13 @@ Assess the project status using these lenses:
 - stabilization signals: docs, tests, refactors, cleanup, architecture work
 - expansion signals: new subsystems, new feature threads, exploratory issues
 
+When previous-window comparison is available, evaluate whether:
+
+- merged throughput is rising, flat, or falling
+- open PR pressure is growing faster than merged throughput
+- open issue count is accumulating or shrinking
+- new labels, terms, or path clusters indicate a genuine new direction rather than noise
+
 Status labels should be plain and descriptive, for example:
 
 - "active delivery with moderate review queue"
@@ -69,12 +76,15 @@ Only infer next directions from patterns such as:
 
 Always mark these statements as inference or likely direction.
 
+If a new direction is inferred from only one PR or issue, say that confidence is low.
+
 ## Report Checklist
 
 Before finalizing the report, ensure it includes:
 
 - explicit monitoring window
 - total issue and PR counts for the window
+- comparison notes when a previous-window sample was collected
 - at least 3 concrete linked artifacts in the evidence section when available
 - a clear distinction between current facts and future inference
 - a statement of uncertainty if labels, file paths, or sample size are weak

--- a/skills/loong-monitor/references/analysis-framework.md
+++ b/skills/loong-monitor/references/analysis-framework.md
@@ -78,6 +78,24 @@ Always mark these statements as inference or likely direction.
 
 If a new direction is inferred from only one PR or issue, say that confidence is low.
 
+## Confidence Guidance
+
+Use an explicit confidence statement in the report.
+
+Higher confidence requires most of these conditions:
+
+- a non-trivial sample of recent PRs and issues
+- enough detailed PR lookups to support path-level subsystem claims
+- useful label coverage or repeated specific title terms
+- a non-empty previous window when you make trend claims
+
+Lower confidence is appropriate when:
+
+- the sample is small
+- labels are sparse or noisy
+- detailed path coverage is limited
+- the previous comparison window is empty or nearly empty
+
 ## Report Checklist
 
 Before finalizing the report, ensure it includes:

--- a/skills/loong-monitor/scripts/collect_repo_activity.py
+++ b/skills/loong-monitor/scripts/collect_repo_activity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import time
 import subprocess
 import sys
 from collections import Counter
@@ -80,17 +81,31 @@ def parse_args() -> argparse.Namespace:
 
 
 def run_json(command: list[str]) -> Any:
-    try:
-        completed = subprocess.run(
-            command,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        sys.stderr.write(exc.stderr)
-        raise
-    return json.loads(completed.stdout)
+    last_exc: subprocess.CalledProcessError | None = None
+    for attempt in range(3):
+        try:
+            completed = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return json.loads(completed.stdout)
+        except subprocess.CalledProcessError as exc:
+            last_exc = exc
+            stderr = exc.stderr or ""
+            retryable = (
+                "TLS handshake timeout" in stderr
+                or "timeout" in stderr.lower()
+                or "connection reset" in stderr.lower()
+                or "temporarily unavailable" in stderr.lower()
+            )
+            if not retryable or attempt == 2:
+                sys.stderr.write(stderr)
+                raise
+            time.sleep(1.5 * (attempt + 1))
+    assert last_exc is not None
+    raise last_exc
 
 
 def iso_date(value: str) -> date:

--- a/skills/loong-monitor/scripts/collect_repo_activity.py
+++ b/skills/loong-monitor/scripts/collect_repo_activity.py
@@ -71,6 +71,11 @@ def parse_args() -> argparse.Namespace:
         required=True,
         help="Directory where activity.json and summary.md will be written.",
     )
+    parser.add_argument(
+        "--compare-previous",
+        action="store_true",
+        help="Also collect a same-length previous window and compute deltas.",
+    )
     return parser.parse_args()
 
 
@@ -98,6 +103,13 @@ def compute_window(args: argparse.Namespace) -> tuple[date, date]:
     if since > until:
         raise SystemExit("--since must be on or before --until")
     return since, until
+
+
+def previous_window(since: date, until: date) -> tuple[date, date]:
+    span_days = (until - since).days + 1
+    previous_until = since - timedelta(days=1)
+    previous_since = previous_until - timedelta(days=span_days - 1)
+    return previous_since, previous_until
 
 
 def search_items(repo: str, kind: str, since: date, until: date, limit: int) -> list[dict[str, Any]]:
@@ -280,6 +292,51 @@ def item_counts(
     }
 
 
+def diff_counts(current: dict[str, Any], previous: dict[str, Any]) -> dict[str, int]:
+    return {
+        "prs_total": current["prs"]["total"] - previous["prs"]["total"],
+        "prs_merged": current["prs"]["merged"] - previous["prs"]["merged"],
+        "prs_open": current["prs"]["open"] - previous["prs"]["open"],
+        "issues_total": current["issues"]["total"] - previous["issues"]["total"],
+        "issues_open": current["issues"]["open"] - previous["issues"]["open"],
+    }
+
+
+def emerging_names(
+    current_items: list[dict[str, int]],
+    previous_items: list[dict[str, int]],
+    key: str,
+) -> list[str]:
+    previous_names = {item[key] for item in previous_items}
+    emerging = [item[key] for item in current_items if item[key] not in previous_names]
+    return emerging[:5]
+
+
+def build_comparison(
+    current_summary: dict[str, Any],
+    previous_summary: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "previous": previous_summary,
+        "delta": diff_counts(current_summary["counts"], previous_summary["counts"]),
+        "emerging_labels": emerging_names(
+            current_summary["top_labels"],
+            previous_summary["top_labels"],
+            "label",
+        ),
+        "emerging_terms": emerging_names(
+            current_summary["top_terms"],
+            previous_summary["top_terms"],
+            "term",
+        ),
+        "emerging_paths": emerging_names(
+            current_summary["top_paths"],
+            previous_summary["top_paths"],
+            "path",
+        ),
+    }
+
+
 def build_summary(
     repo: str,
     since: date,
@@ -287,6 +344,7 @@ def build_summary(
     pr_search: list[dict[str, Any]],
     issue_search: list[dict[str, Any]],
     summary: dict[str, Any],
+    comparison: dict[str, Any] | None = None,
 ) -> str:
     lines = [
         f"# Activity Summary for {repo}",
@@ -340,6 +398,41 @@ def build_summary(
     else:
         lines.append("- No author activity detected.")
 
+    if comparison is not None:
+        previous = comparison["previous"]
+        delta = comparison["delta"]
+        lines.extend(
+            [
+                "",
+                "## Comparison To Previous Window",
+                (
+                    "- Previous window: "
+                    f"{previous['window']['since']} to {previous['window']['until']}"
+                ),
+                (
+                    "- PR volume delta: "
+                    f"{delta['prs_total']:+d} total, {delta['prs_merged']:+d} merged, "
+                    f"{delta['prs_open']:+d} open"
+                ),
+                (
+                    "- Issue volume delta: "
+                    f"{delta['issues_total']:+d} total, {delta['issues_open']:+d} open"
+                ),
+            ]
+        )
+        if comparison["emerging_paths"]:
+            lines.append(
+                "- Emerging paths: " + ", ".join(comparison["emerging_paths"])
+            )
+        if comparison["emerging_labels"]:
+            lines.append(
+                "- Emerging labels: " + ", ".join(comparison["emerging_labels"])
+            )
+        if comparison["emerging_terms"]:
+            lines.append(
+                "- Emerging title terms: " + ", ".join(comparison["emerging_terms"])
+            )
+
     lines.extend(["", "## High-Discussion PRs"])
     if summary["counts"]["high_discussion_prs"]:
         lines.extend(
@@ -373,25 +466,30 @@ def build_summary(
     return "\n".join(lines) + "\n"
 
 
-def main() -> int:
-    args = parse_args()
-    since, until = compute_window(args)
-    output_dir = Path(args.output)
-    output_dir.mkdir(parents=True, exist_ok=True)
+def collect_window(
+    repo: str,
+    since: date,
+    until: date,
+    limit: int,
+    detail_limit: int,
+) -> dict[str, Any]:
+    pr_search = search_items(repo, "pr", since, until, limit)
+    issue_search = search_items(repo, "issue", since, until, limit)
 
-    pr_search = search_items(args.repo, "pr", since, until, args.limit)
-    issue_search = search_items(args.repo, "issue", since, until, args.limit)
-
-    pr_numbers = [item["number"] for item in pr_search[: args.detail_limit]]
-    issue_numbers = [item["number"] for item in issue_search[: args.detail_limit]]
+    pr_numbers = [item["number"] for item in pr_search[:detail_limit]]
+    issue_numbers = [item["number"] for item in issue_search[:detail_limit]]
     pr_snapshot_numbers = [item["number"] for item in pr_search]
 
-    prs = [pr_detail(args.repo, number) for number in pr_numbers]
-    issues = [issue_detail(args.repo, number) for number in issue_numbers]
-    pr_snapshots = [pr_snapshot(args.repo, number) for number in pr_snapshot_numbers]
+    prs = [pr_detail(repo, number) for number in pr_numbers]
+    issues = [issue_detail(repo, number) for number in issue_numbers]
+    pr_snapshots = [pr_snapshot(repo, number) for number in pr_snapshot_numbers]
 
     summary = {
-        "detail_limit": args.detail_limit,
+        "window": {
+            "since": since.isoformat(),
+            "until": until.isoformat(),
+        },
+        "detail_limit": detail_limit,
         "counts": item_counts(pr_search, issue_search, pr_snapshots, prs, issues),
         "top_labels": extract_top_labels(pr_search + issue_search),
         "top_authors": top_authors(pr_search + issue_search),
@@ -399,15 +497,10 @@ def main() -> int:
         "top_terms": title_terms(pr_search + issue_search),
     }
 
-    payload = {
-        "repo": args.repo,
+    return {
         "window": {
             "since": since.isoformat(),
             "until": until.isoformat(),
-        },
-        "limits": {
-            "search_limit": args.limit,
-            "detail_limit": args.detail_limit,
         },
         "summary": summary,
         "pr_search": pr_search,
@@ -417,11 +510,60 @@ def main() -> int:
         "issues": issues,
     }
 
+
+def main() -> int:
+    args = parse_args()
+    since, until = compute_window(args)
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    current = collect_window(args.repo, since, until, args.limit, args.detail_limit)
+    comparison = None
+    previous = None
+    if args.compare_previous:
+        prev_since, prev_until = previous_window(since, until)
+        previous = collect_window(
+            args.repo,
+            prev_since,
+            prev_until,
+            args.limit,
+            args.detail_limit,
+        )
+        comparison = build_comparison(current["summary"], previous["summary"])
+
+    payload = {
+        "repo": args.repo,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "window": {
+            "since": since.isoformat(),
+            "until": until.isoformat(),
+        },
+        "limits": {
+            "search_limit": args.limit,
+            "detail_limit": args.detail_limit,
+        },
+        "summary": current["summary"],
+        "comparison": comparison,
+        "pr_search": current["pr_search"],
+        "issue_search": current["issue_search"],
+        "pr_snapshots": current["pr_snapshots"],
+        "prs": current["prs"],
+        "issues": current["issues"],
+        "previous_window": previous,
+    }
+
     activity_path = output_dir / "activity.json"
     summary_path = output_dir / "summary.md"
     activity_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     summary_path.write_text(
-        build_summary(args.repo, since, until, pr_search, issue_search, summary),
+        build_summary(
+            args.repo,
+            since,
+            until,
+            current["pr_search"],
+            current["issue_search"],
+            current["summary"],
+            comparison,
+        ),
         encoding="utf-8",
     )
 

--- a/skills/loong-monitor/scripts/collect_repo_activity.py
+++ b/skills/loong-monitor/scripts/collect_repo_activity.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Collect GitHub issue and PR activity for a monitoring window."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+TITLE_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "api",
+    "bug",
+    "by",
+    "docs",
+    "doc",
+    "feat",
+    "feature",
+    "for",
+    "from",
+    "fix",
+    "in",
+    "into",
+    "on",
+    "of",
+    "or",
+    "pr",
+    "refactor",
+    "repo",
+    "the",
+    "to",
+    "update",
+    "with",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Collect recent issue and pull request activity for a GitHub repository."
+    )
+    parser.add_argument("--repo", required=True, help="GitHub repository in owner/name form.")
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="Monitoring window length in days when --since is not provided.",
+    )
+    parser.add_argument("--since", help="Window start date in YYYY-MM-DD format.")
+    parser.add_argument("--until", help="Window end date in YYYY-MM-DD format.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=60,
+        help="Maximum number of issues and PRs to collect per type.",
+    )
+    parser.add_argument(
+        "--detail-limit",
+        type=int,
+        default=25,
+        help="Maximum number of issue and PR detail lookups per type.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Directory where activity.json and summary.md will be written.",
+    )
+    return parser.parse_args()
+
+
+def run_json(command: list[str]) -> Any:
+    try:
+        completed = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(exc.stderr)
+        raise
+    return json.loads(completed.stdout)
+
+
+def iso_date(value: str) -> date:
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def compute_window(args: argparse.Namespace) -> tuple[date, date]:
+    until = iso_date(args.until) if args.until else datetime.now(timezone.utc).date()
+    since = iso_date(args.since) if args.since else until - timedelta(days=args.days)
+    if since > until:
+        raise SystemExit("--since must be on or before --until")
+    return since, until
+
+
+def search_items(repo: str, kind: str, since: date, until: date, limit: int) -> list[dict[str, Any]]:
+    query = f"repo:{repo} is:{kind} updated:{since.isoformat()}..{until.isoformat()}"
+    per_page = min(limit, 100)
+    page = 1
+    items: list[dict[str, Any]] = []
+    while len(items) < limit:
+        page_items = run_json(
+            [
+                "gh",
+                "api",
+                "-X",
+                "GET",
+                "search/issues",
+                "-f",
+                f"q={query}",
+                "-f",
+                "sort=updated",
+                "-f",
+                "order=desc",
+                "-f",
+                f"per_page={per_page}",
+                "-f",
+                f"page={page}",
+            ]
+        )["items"]
+        if not page_items:
+            break
+        items.extend(page_items)
+        if len(page_items) < per_page:
+            break
+        page += 1
+    return items[:limit]
+
+
+def pr_detail(repo: str, number: int) -> dict[str, Any]:
+    return run_json(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            (
+                "number,title,url,state,isDraft,createdAt,updatedAt,closedAt,mergedAt,"
+                "author,labels,reviewDecision,comments,changedFiles,additions,deletions,files"
+            ),
+        ]
+    )
+
+
+def pr_snapshot(repo: str, number: int) -> dict[str, Any]:
+    return run_json(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,state,mergedAt",
+        ]
+    )
+
+
+def issue_detail(repo: str, number: int) -> dict[str, Any]:
+    return run_json(
+        [
+            "gh",
+            "issue",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "number,title,url,state,createdAt,updatedAt,closedAt,author,labels,comments",
+        ]
+    )
+
+
+def title_terms(items: list[dict[str, Any]]) -> list[dict[str, int]]:
+    terms: Counter[str] = Counter()
+    for item in items:
+        title = item.get("title", "").lower()
+        for token in "".join(ch if ch.isalnum() else " " for ch in title).split():
+            if len(token) < 4 or token in TITLE_STOPWORDS:
+                continue
+            terms[token] += 1
+    return [{"term": term, "count": count} for term, count in terms.most_common(10)]
+
+
+def extract_top_labels(items: list[dict[str, Any]]) -> list[dict[str, int]]:
+    labels: Counter[str] = Counter()
+    for item in items:
+        for label in item.get("labels", []):
+            name = label["name"] if isinstance(label, dict) else label
+            labels[name] += 1
+    return [{"label": label, "count": count} for label, count in labels.most_common(10)]
+
+
+def top_authors(items: list[dict[str, Any]]) -> list[dict[str, int]]:
+    authors: Counter[str] = Counter()
+    for item in items:
+        author = item.get("author") or item.get("user") or {}
+        login = author.get("login")
+        if login:
+            authors[login] += 1
+    return [{"author": author, "count": count} for author, count in authors.most_common(10)]
+
+
+def top_paths(prs: list[dict[str, Any]]) -> list[dict[str, int]]:
+    paths: Counter[str] = Counter()
+    for pr in prs:
+        for file_info in pr.get("files", []):
+            path = file_info.get("path", "")
+            if not path:
+                continue
+            parts = [part for part in path.split("/") if part]
+            if not parts:
+                continue
+            prefix = parts[0] if len(parts) == 1 else "/".join(parts[:2])
+            paths[prefix] += 1
+    return [{"path": path, "count": count} for path, count in paths.most_common(10)]
+
+
+def item_counts(
+    pr_search: list[dict[str, Any]],
+    issue_search: list[dict[str, Any]],
+    pr_snapshots: list[dict[str, Any]],
+    detailed_prs: list[dict[str, Any]],
+    detailed_issues: list[dict[str, Any]],
+) -> dict[str, Any]:
+    pr_open = sum(1 for pr in pr_search if pr.get("state", "").lower() == "open")
+    issue_open = sum(1 for issue in issue_search if issue.get("state", "").lower() == "open")
+    merged = sum(1 for pr in pr_snapshots if pr.get("mergedAt"))
+    high_discussion_prs = sorted(
+        detailed_prs,
+        key=lambda item: len(item.get("comments", [])),
+        reverse=True,
+    )[:5]
+    high_discussion_issues = sorted(
+        detailed_issues,
+        key=lambda item: len(item.get("comments", [])),
+        reverse=True,
+    )[:5]
+    return {
+        "prs": {
+            "total": len(pr_search),
+            "merged": merged,
+            "open": pr_open,
+            "closed_unmerged": len(pr_search) - merged - pr_open,
+        },
+        "issues": {
+            "total": len(issue_search),
+            "open": issue_open,
+            "closed": len(issue_search) - issue_open,
+        },
+        "high_discussion_prs": [
+            {
+                "number": item["number"],
+                "title": item["title"],
+                "comments": len(item.get("comments", [])),
+                "url": item["url"],
+            }
+            for item in high_discussion_prs
+        ],
+        "high_discussion_issues": [
+            {
+                "number": item["number"],
+                "title": item["title"],
+                "comments": len(item.get("comments", [])),
+                "url": item["url"],
+            }
+            for item in high_discussion_issues
+        ],
+    }
+
+
+def build_summary(
+    repo: str,
+    since: date,
+    until: date,
+    pr_search: list[dict[str, Any]],
+    issue_search: list[dict[str, Any]],
+    summary: dict[str, Any],
+) -> str:
+    lines = [
+        f"# Activity Summary for {repo}",
+        "",
+        f"- Window: {since.isoformat()} to {until.isoformat()}",
+        f"- PRs collected: {summary['counts']['prs']['total']}",
+        f"- Issues collected: {summary['counts']['issues']['total']}",
+        f"- Merged PRs: {summary['counts']['prs']['merged']}",
+        f"- Open PRs: {summary['counts']['prs']['open']}",
+        f"- Open issues: {summary['counts']['issues']['open']}",
+        (
+            "- Detailed lookups used for file-path and discussion signals: "
+            f"top {min(len(pr_search), summary['detail_limit'])} PRs and "
+            f"top {min(len(issue_search), summary['detail_limit'])} issues"
+        ),
+        "",
+        "## Top Labels",
+    ]
+    if summary["top_labels"]:
+        lines.extend(
+            f"- {item['label']}: {item['count']}"
+            for item in summary["top_labels"]
+        )
+    else:
+        lines.append("- No labels found in collected items.")
+
+    lines.extend(["", "## Top Touched Paths"])
+    if summary["top_paths"]:
+        lines.extend(
+            f"- {item['path']}: {item['count']}"
+            for item in summary["top_paths"]
+        )
+    else:
+        lines.append("- No file-path details available from collected PRs.")
+
+    lines.extend(["", "## Common Title Terms"])
+    if summary["top_terms"]:
+        lines.extend(
+            f"- {item['term']}: {item['count']}"
+            for item in summary["top_terms"]
+        )
+    else:
+        lines.append("- No strong recurring title terms detected.")
+
+    lines.extend(["", "## Most Active Authors"])
+    if summary["top_authors"]:
+        lines.extend(
+            f"- {item['author']}: {item['count']}"
+            for item in summary["top_authors"]
+        )
+    else:
+        lines.append("- No author activity detected.")
+
+    lines.extend(["", "## High-Discussion PRs"])
+    if summary["counts"]["high_discussion_prs"]:
+        lines.extend(
+            f"- PR #{item['number']} ({item['comments']} comments): {item['title']} - {item['url']}"
+            for item in summary["counts"]["high_discussion_prs"]
+        )
+    else:
+        lines.append("- None.")
+
+    lines.extend(["", "## High-Discussion Issues"])
+    if summary["counts"]["high_discussion_issues"]:
+        lines.extend(
+            f"- Issue #{item['number']} ({item['comments']} comments): {item['title']} - {item['url']}"
+            for item in summary["counts"]["high_discussion_issues"]
+        )
+    else:
+        lines.append("- None.")
+
+    lines.extend(["", "## Recent PRs"])
+    lines.extend(
+        f"- PR #{pr['number']} [{str(pr['state']).upper()}] {pr['title']} - {pr['html_url']}"
+        for pr in pr_search[:10]
+    )
+
+    lines.extend(["", "## Recent Issues"])
+    lines.extend(
+        f"- Issue #{issue['number']} [{str(issue['state']).upper()}] {issue['title']} - {issue['html_url']}"
+        for issue in issue_search[:10]
+    )
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    since, until = compute_window(args)
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    pr_search = search_items(args.repo, "pr", since, until, args.limit)
+    issue_search = search_items(args.repo, "issue", since, until, args.limit)
+
+    pr_numbers = [item["number"] for item in pr_search[: args.detail_limit]]
+    issue_numbers = [item["number"] for item in issue_search[: args.detail_limit]]
+    pr_snapshot_numbers = [item["number"] for item in pr_search]
+
+    prs = [pr_detail(args.repo, number) for number in pr_numbers]
+    issues = [issue_detail(args.repo, number) for number in issue_numbers]
+    pr_snapshots = [pr_snapshot(args.repo, number) for number in pr_snapshot_numbers]
+
+    summary = {
+        "detail_limit": args.detail_limit,
+        "counts": item_counts(pr_search, issue_search, pr_snapshots, prs, issues),
+        "top_labels": extract_top_labels(pr_search + issue_search),
+        "top_authors": top_authors(pr_search + issue_search),
+        "top_paths": top_paths(prs),
+        "top_terms": title_terms(pr_search + issue_search),
+    }
+
+    payload = {
+        "repo": args.repo,
+        "window": {
+            "since": since.isoformat(),
+            "until": until.isoformat(),
+        },
+        "limits": {
+            "search_limit": args.limit,
+            "detail_limit": args.detail_limit,
+        },
+        "summary": summary,
+        "pr_search": pr_search,
+        "issue_search": issue_search,
+        "pr_snapshots": pr_snapshots,
+        "prs": prs,
+        "issues": issues,
+    }
+
+    activity_path = output_dir / "activity.json"
+    summary_path = output_dir / "summary.md"
+    activity_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    summary_path.write_text(
+        build_summary(args.repo, since, until, pr_search, issue_search, summary),
+        encoding="utf-8",
+    )
+
+    print(f"Wrote {activity_path}")
+    print(f"Wrote {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/loong-monitor/scripts/generate_report.py
+++ b/skills/loong-monitor/scripts/generate_report.py
@@ -333,6 +333,7 @@ def render_report(payload: dict[str, Any]) -> str:
     comparison = payload.get("comparison")
     focus_areas = choose_focus_areas(summary)
     generated_at = payload.get("generated_at") or datetime.now(timezone.utc).isoformat()
+    run_metadata = payload.get("run_metadata") or {}
 
     lines = [
         "# LoongClaw Monitor Report",
@@ -340,10 +341,10 @@ def render_report(payload: dict[str, Any]) -> str:
         f"- Repository: `{payload['repo']}`",
         f"- Monitoring window: {payload['window']['since']} to {payload['window']['until']}",
         f"- Generated at: {generated_at}",
-        "",
-        "## Executive Summary",
-        "",
     ]
+    if run_metadata.get("preset"):
+        lines.append(f"- Run preset: `{run_metadata['preset']}`")
+    lines.extend(["", "## Executive Summary", ""])
     lines.extend(f"- {line}" for line in executive_summary(payload))
 
     lines.extend(["", "## Current Focus Areas", ""])

--- a/skills/loong-monitor/scripts/generate_report.py
+++ b/skills/loong-monitor/scripts/generate_report.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Generate a Markdown monitoring report from collected repo activity."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a Markdown report from loong-monitor activity.json."
+    )
+    parser.add_argument(
+        "--activity",
+        required=True,
+        help="Path to activity.json produced by collect_repo_activity.py.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path where the Markdown report will be written.",
+    )
+    return parser.parse_args()
+
+
+def load_activity(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def count_value(summary: dict[str, Any], group: str, name: str) -> int:
+    return int(summary["counts"][group][name])
+
+
+def choose_focus_areas(summary: dict[str, Any]) -> list[dict[str, str]]:
+    path_items = summary.get("top_paths", [])
+    label_items = summary.get("top_labels", [])
+    term_items = summary.get("top_terms", [])
+    discussion_prs = summary["counts"].get("high_discussion_prs", [])
+    evidence_urls = [item["url"] for item in discussion_prs[:2]]
+
+    def labels_line(limit: int = 3) -> str:
+        labels = [item["label"] for item in label_items[:limit]]
+        return ", ".join(labels) if labels else "few stable labels"
+
+    def terms_line(limit: int = 3) -> str:
+        terms = [item["term"] for item in term_items[:limit]]
+        return ", ".join(terms) if terms else "no strong recurring title terms"
+
+    focus_areas: list[dict[str, str]] = []
+    seen_titles: set[str] = set()
+
+    for item in path_items:
+        path = item["path"]
+        count = item["count"]
+        if path.startswith("docs/"):
+            title = "Documentation, planning, and architecture surfaces"
+            detail = (
+                f"Recent touched paths are concentrated in `{path}` and nearby docs paths, "
+                f"which suggests active design, planning, or public-facing documentation work. "
+                f"Supporting signals: labels `{labels_line()}` and terms `{terms_line()}`."
+            )
+        elif path.startswith("crates/daemon"):
+            title = "Daemon and runtime operations"
+            detail = (
+                f"`{path}` is one of the heaviest touched areas, pointing to operational runtime, "
+                f"diagnostics, onboarding, or delivery-path work. Supporting signals: labels "
+                f"`{labels_line()}` and terms `{terms_line()}`."
+            )
+        elif path.startswith("crates/app"):
+            title = "Application and conversation runtime"
+            detail = (
+                f"`{path}` appears repeatedly in recent PRs, which suggests current attention on "
+                f"user-facing runtime flow, orchestration, or interaction behavior."
+            )
+        elif path.startswith("crates/kernel") or path.startswith("crates/contracts"):
+            title = "Kernel and contract shaping"
+            detail = (
+                f"Touches in `{path}` indicate work on core semantics, shared boundaries, or "
+                f"foundation-layer behavior."
+            )
+        elif path.startswith(".github/") or path.startswith("scripts/"):
+            title = "CI and delivery reliability"
+            detail = (
+                f"`{path}` indicates attention on automation, validation, or delivery flow stability."
+            )
+        else:
+            title = f"Activity centered on `{path}`"
+            detail = (
+                f"`{path}` appears {count} times across detailed PR file lists, making it one of the "
+                f"more active clusters in the current monitoring window."
+            )
+
+        if title in seen_titles:
+            continue
+        seen_titles.add(title)
+        focus_areas.append(
+            {
+                "title": title,
+                "detail": detail,
+                "evidence": ", ".join(evidence_urls) if evidence_urls else "See recent PR evidence in the appendix.",
+            }
+        )
+        if len(focus_areas) == 3:
+            break
+
+    if not focus_areas:
+        focus_areas.append(
+            {
+                "title": "No strong path cluster detected",
+                "detail": "The current sample does not show a clear dominant path cluster, so conclusions should stay conservative.",
+                "evidence": "Use the evidence appendix and high-discussion items for manual review.",
+            }
+        )
+
+    return focus_areas
+
+
+def status_line(summary: dict[str, Any], comparison: dict[str, Any] | None) -> str:
+    merged = count_value(summary, "prs", "merged")
+    open_prs = count_value(summary, "prs", "open")
+    open_issues = count_value(summary, "issues", "open")
+
+    if merged >= 5 and open_prs >= 5:
+        status = "active delivery with a substantial in-flight queue"
+    elif merged >= 3 and open_prs >= 3:
+        status = "steady delivery with ongoing implementation threads"
+    elif open_prs > merged:
+        status = "active work in progress with landing throughput lagging the queue"
+    else:
+        status = "moderate activity with a relatively light landing cadence"
+
+    if comparison is None:
+        return status
+
+    delta = comparison["delta"]
+    previous_total = (
+        comparison["previous"]["counts"]["prs"]["total"]
+        + comparison["previous"]["counts"]["issues"]["total"]
+    )
+    if previous_total == 0:
+        return status + " after a quiet previous window"
+
+    if delta["prs_merged"] > 0:
+        status += "; merged throughput is up versus the previous window"
+    elif delta["prs_merged"] < 0:
+        status += "; merged throughput is down versus the previous window"
+
+    if delta["issues_open"] > 0:
+        status += " and open issue pressure is increasing"
+    elif delta["issues_open"] < 0:
+        status += " and open issue pressure is easing"
+
+    return status
+
+
+def executive_summary(payload: dict[str, Any]) -> list[str]:
+    summary = payload["summary"]
+    comparison = payload.get("comparison")
+    lines = [
+        (
+            f"The repository shows {status_line(summary, comparison)} during "
+            f"{payload['window']['since']} to {payload['window']['until']}."
+        ),
+        (
+            f"The current sample includes {count_value(summary, 'prs', 'total')} PRs, "
+            f"{count_value(summary, 'prs', 'merged')} merged PRs, and "
+            f"{count_value(summary, 'issues', 'open')} open issues."
+        ),
+    ]
+
+    top_paths = summary.get("top_paths", [])
+    if top_paths:
+        lines.append(
+            f"The heaviest detailed file activity is concentrated in `{top_paths[0]['path']}`"
+            + (
+                f" and `{top_paths[1]['path']}`."
+                if len(top_paths) > 1
+                else "."
+            )
+        )
+
+    if comparison:
+        delta = comparison["delta"]
+        previous_total = (
+            comparison["previous"]["counts"]["prs"]["total"]
+            + comparison["previous"]["counts"]["issues"]["total"]
+        )
+        if previous_total == 0:
+            lines.append(
+                "The previous same-length window had no collected PR or issue activity, so the current burst should be treated as a fresh active phase rather than a subtle trend change."
+            )
+        else:
+            lines.append(
+                "Compared with the previous window, "
+                f"PR volume changed by {delta['prs_total']:+d}, merged PRs by {delta['prs_merged']:+d}, "
+                f"and open issues by {delta['issues_open']:+d}."
+            )
+
+    return lines
+
+
+def current_status_points(summary: dict[str, Any], comparison: dict[str, Any] | None) -> list[str]:
+    points = [
+        f"Merged PR activity: {count_value(summary, 'prs', 'merged')} merged in the current window.",
+        f"Active PR queue: {count_value(summary, 'prs', 'open')} open PRs in the collected sample.",
+        f"Issue pressure: {count_value(summary, 'issues', 'open')} open issues in the collected sample.",
+    ]
+    if comparison:
+        delta = comparison["delta"]
+        previous_total = (
+            comparison["previous"]["counts"]["prs"]["total"]
+            + comparison["previous"]["counts"]["issues"]["total"]
+        )
+        if previous_total == 0:
+            points.append(
+                "The previous same-length window had no collected activity, so the current window effectively establishes the recent baseline."
+            )
+        else:
+            points.append(
+                "Window-over-window deltas: "
+                f"PRs {delta['prs_total']:+d}, merged {delta['prs_merged']:+d}, "
+                f"open PRs {delta['prs_open']:+d}, open issues {delta['issues_open']:+d}."
+            )
+    return points
+
+
+def risks_and_questions(summary: dict[str, Any], comparison: dict[str, Any] | None) -> list[str]:
+    risks: list[str] = []
+    merged = count_value(summary, "prs", "merged")
+    open_prs = count_value(summary, "prs", "open")
+    open_issues = count_value(summary, "issues", "open")
+
+    if open_prs >= max(5, merged * 2):
+        risks.append(
+            "The open PR queue is materially larger than recent merged throughput, which may indicate review bandwidth pressure or large in-flight changes."
+        )
+
+    if open_issues >= 10:
+        risks.append(
+            "Open issue volume is non-trivial, so backlog growth and prioritization discipline should be watched closely."
+        )
+
+    discussion_prs = summary["counts"].get("high_discussion_prs", [])
+    if discussion_prs:
+        risks.append(
+            f"PR #{discussion_prs[0]['number']} is among the highest-discussion threads, so it may represent a hotspot for review friction or design negotiation."
+        )
+
+    if (
+        comparison
+        and comparison["delta"]["issues_open"] > 0
+        and (
+            comparison["previous"]["counts"]["prs"]["total"]
+            + comparison["previous"]["counts"]["issues"]["total"]
+        )
+        > 0
+    ):
+        risks.append(
+            "Open issues increased versus the previous window, which suggests unresolved work may be accumulating faster than it is being retired."
+        )
+
+    if not risks:
+        risks.append("No dominant risk signal stands out from the current evidence sample, but the report should still be read as directional rather than exhaustive.")
+
+    return risks
+
+
+def likely_next_directions(payload: dict[str, Any]) -> list[str]:
+    summary = payload["summary"]
+    comparison = payload.get("comparison")
+    directions: list[str] = []
+    open_prs = [
+        item for item in payload.get("pr_search", [])
+        if str(item.get("state", "")).lower() == "open"
+    ]
+    open_issues = [
+        item for item in payload.get("issue_search", [])
+        if str(item.get("state", "")).lower() == "open"
+    ]
+
+    for item in open_prs[:2]:
+        directions.append(
+            f"Likely near-term follow-through remains around PR #{item['number']} because it is still open and sits near the front of the recent activity queue."
+        )
+
+    for item in open_issues[:2]:
+        directions.append(
+            f"Issue #{item['number']} is a plausible candidate to shape upcoming work because it is still open and recently updated within the monitoring window."
+        )
+
+    if comparison:
+        if comparison["emerging_paths"]:
+            directions.append(
+                "New path clusters are appearing in "
+                + ", ".join(f"`{path}`" for path in comparison["emerging_paths"][:3])
+                + ", which may signal a broadening work frontier."
+            )
+        if comparison["emerging_terms"]:
+            directions.append(
+                "Emerging title language such as "
+                + ", ".join(f"`{term}`" for term in comparison["emerging_terms"][:3])
+                + " suggests new emphasis areas worth tracking in the next report."
+            )
+
+    if not directions:
+        directions.append(
+            "The current evidence does not strongly separate one next direction from another, so follow-up reporting should wait for another cycle of PR and issue movement."
+        )
+
+    return directions[:4]
+
+
+def evidence_appendix(payload: dict[str, Any]) -> list[str]:
+    summary = payload["summary"]
+    appendix: list[str] = []
+    for item in summary["counts"].get("high_discussion_prs", [])[:5]:
+        appendix.append(
+            f"- PR #{item['number']}: {item['title']} ({item['comments']} comments) - {item['url']}"
+        )
+    for item in summary["counts"].get("high_discussion_issues", [])[:5]:
+        appendix.append(
+            f"- Issue #{item['number']}: {item['title']} ({item['comments']} comments) - {item['url']}"
+        )
+    return appendix
+
+
+def render_report(payload: dict[str, Any]) -> str:
+    summary = payload["summary"]
+    comparison = payload.get("comparison")
+    focus_areas = choose_focus_areas(summary)
+    generated_at = payload.get("generated_at") or datetime.now(timezone.utc).isoformat()
+
+    lines = [
+        "# LoongClaw Monitor Report",
+        "",
+        f"- Repository: `{payload['repo']}`",
+        f"- Monitoring window: {payload['window']['since']} to {payload['window']['until']}",
+        f"- Generated at: {generated_at}",
+        "",
+        "## Executive Summary",
+        "",
+    ]
+    lines.extend(f"- {line}" for line in executive_summary(payload))
+
+    lines.extend(["", "## Current Focus Areas", ""])
+    for area in focus_areas:
+        lines.append(f"- {area['title']}: {area['detail']}")
+        lines.append(f"  Evidence: {area['evidence']}")
+
+    lines.extend(["", "## Current Status", ""])
+    lines.extend(f"- {line}" for line in current_status_points(summary, comparison))
+
+    lines.extend(["", "## Risks And Open Questions", ""])
+    lines.extend(f"- {line}" for line in risks_and_questions(summary, comparison))
+
+    lines.extend(["", "## Likely Next Directions", ""])
+    lines.extend(f"- {line}" for line in likely_next_directions(payload))
+
+    lines.extend(["", "## Evidence Appendix", ""])
+    lines.extend(evidence_appendix(payload))
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    activity_path = Path(args.activity)
+    output_path = Path(args.output)
+    payload = load_activity(activity_path)
+    report = render_report(payload)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report, encoding="utf-8")
+    print(f"Wrote {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/loong-monitor/scripts/generate_report.py
+++ b/skills/loong-monitor/scripts/generate_report.py
@@ -35,6 +35,15 @@ def count_value(summary: dict[str, Any], group: str, name: str) -> int:
     return int(summary["counts"][group][name])
 
 
+def detail_coverage(payload: dict[str, Any]) -> float:
+    summary = payload["summary"]
+    total_items = count_value(summary, "prs", "total") + count_value(summary, "issues", "total")
+    if total_items == 0:
+        return 0.0
+    detailed_items = len(payload.get("prs", [])) + len(payload.get("issues", []))
+    return detailed_items / total_items
+
+
 def choose_focus_areas(summary: dict[str, Any]) -> list[dict[str, str]]:
     path_items = summary.get("top_paths", [])
     label_items = summary.get("top_labels", [])
@@ -269,6 +278,64 @@ def risks_and_questions(summary: dict[str, Any], comparison: dict[str, Any] | No
     return risks
 
 
+def confidence_and_uncertainty(payload: dict[str, Any]) -> tuple[str, list[str]]:
+    summary = payload["summary"]
+    comparison = payload.get("comparison")
+    evidence_points = count_value(summary, "prs", "total") + count_value(summary, "issues", "total")
+    top_labels = len(summary.get("top_labels", []))
+    top_paths = len(summary.get("top_paths", []))
+    coverage = detail_coverage(payload)
+    previous_total = 0
+    if comparison:
+        previous_total = (
+            comparison["previous"]["counts"]["prs"]["total"]
+            + comparison["previous"]["counts"]["issues"]["total"]
+        )
+
+    reasons: list[str] = []
+    score = 0
+
+    if evidence_points >= 20:
+        score += 2
+        reasons.append("The report is based on a non-trivial activity sample across PRs and issues.")
+    elif evidence_points >= 10:
+        score += 1
+        reasons.append("The report has a moderate activity sample, which is usable but not exhaustive.")
+    else:
+        reasons.append("The activity sample is small, so conclusions should be treated cautiously.")
+
+    if top_labels >= 5:
+        score += 1
+        reasons.append("Label coverage is reasonably rich, which helps identify active themes.")
+    else:
+        reasons.append("Label coverage is sparse, so thematic clustering is weaker than ideal.")
+
+    if top_paths >= 3 and coverage >= 0.5:
+        score += 1
+        reasons.append("Detailed PR lookups cover enough items to support file-path-based focus inference.")
+    elif top_paths == 0:
+        reasons.append("Path-level evidence is weak or absent, which limits subsystem confidence.")
+    else:
+        reasons.append("Only part of the activity sample has detailed path coverage, so subsystem conclusions are directional.")
+
+    if comparison:
+        if previous_total > 0:
+            score += 1
+            reasons.append("Previous-window data exists, so trend statements have an actual baseline.")
+        else:
+            score -= 1
+            reasons.append("The previous comparison window had no collected activity, so trend statements are less reliable than current-state statements.")
+
+    if score >= 4:
+        level = "High"
+    elif score >= 2:
+        level = "Medium"
+    else:
+        level = "Low"
+
+    return level, reasons
+
+
 def likely_next_directions(payload: dict[str, Any]) -> list[str]:
     summary = payload["summary"]
     comparison = payload.get("comparison")
@@ -334,6 +401,7 @@ def render_report(payload: dict[str, Any]) -> str:
     focus_areas = choose_focus_areas(summary)
     generated_at = payload.get("generated_at") or datetime.now(timezone.utc).isoformat()
     run_metadata = payload.get("run_metadata") or {}
+    confidence_level, confidence_reasons = confidence_and_uncertainty(payload)
 
     lines = [
         "# LoongClaw Monitor Report",
@@ -357,6 +425,10 @@ def render_report(payload: dict[str, Any]) -> str:
 
     lines.extend(["", "## Risks And Open Questions", ""])
     lines.extend(f"- {line}" for line in risks_and_questions(summary, comparison))
+
+    lines.extend(["", "## Confidence And Uncertainty", ""])
+    lines.append(f"- Confidence level: {confidence_level}")
+    lines.extend(f"- {line}" for line in confidence_reasons)
 
     lines.extend(["", "## Likely Next Directions", ""])
     lines.extend(f"- {line}" for line in likely_next_directions(payload))

--- a/skills/loong-monitor/scripts/run_monitor_cycle.py
+++ b/skills/loong-monitor/scripts/run_monitor_cycle.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Run a preset loong-monitor collection and report generation cycle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run loong-monitor in one step for weekly or monthly reporting."
+    )
+    parser.add_argument(
+        "--repo",
+        default="loongclaw-ai/loongclaw",
+        help="GitHub repository in owner/name form.",
+    )
+    parser.add_argument(
+        "--preset",
+        choices=["weekly", "monthly"],
+        required=True,
+        help="Reporting preset. weekly=last 7 days, monthly=last 30 days.",
+    )
+    parser.add_argument(
+        "--until",
+        help="Optional window end date in YYYY-MM-DD format. Defaults to today in UTC.",
+    )
+    parser.add_argument(
+        "--output-root",
+        default="/tmp/loong-monitor-runs",
+        help="Directory under which the run directory will be created.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=60,
+        help="Maximum number of issues and PRs to collect per type.",
+    )
+    parser.add_argument(
+        "--detail-limit",
+        type=int,
+        default=25,
+        help="Maximum number of detailed PR and issue lookups per type.",
+    )
+    parser.add_argument(
+        "--no-compare-previous",
+        action="store_true",
+        help="Disable previous-window comparison for this run.",
+    )
+    return parser.parse_args()
+
+
+def parse_date(value: str) -> date:
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def compute_window(preset: str, until: date) -> tuple[date, date]:
+    days = 7 if preset == "weekly" else 30
+    since = until - timedelta(days=days - 1)
+    return since, until
+
+
+def slug_repo(repo: str) -> str:
+    return repo.replace("/", "__")
+
+
+def run_command(command: list[str]) -> None:
+    completed = subprocess.run(command, text=True)
+    if completed.returncode != 0:
+        raise SystemExit(completed.returncode)
+
+
+def enrich_activity_json(activity_path: Path, preset: str, run_dir: Path) -> None:
+    payload = json.loads(activity_path.read_text(encoding="utf-8"))
+    payload["run_metadata"] = {
+        "preset": preset,
+        "run_dir": str(run_dir),
+    }
+    activity_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    until = parse_date(args.until) if args.until else datetime.now(timezone.utc).date()
+    since, until = compute_window(args.preset, until)
+
+    run_dir = (
+        Path(args.output_root)
+        / slug_repo(args.repo)
+        / f"{args.preset}-{since.isoformat()}_to_{until.isoformat()}"
+    )
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    script_dir = Path(__file__).resolve().parent
+    collect_script = script_dir / "collect_repo_activity.py"
+    report_script = script_dir / "generate_report.py"
+
+    collect_command = [
+        sys.executable,
+        str(collect_script),
+        "--repo",
+        args.repo,
+        "--since",
+        since.isoformat(),
+        "--until",
+        until.isoformat(),
+        "--limit",
+        str(args.limit),
+        "--detail-limit",
+        str(args.detail_limit),
+        "--output",
+        str(run_dir),
+    ]
+    if not args.no_compare_previous:
+        collect_command.append("--compare-previous")
+
+    run_command(collect_command)
+    enrich_activity_json(run_dir / "activity.json", args.preset, run_dir)
+    run_command(
+        [
+            sys.executable,
+            str(report_script),
+            "--activity",
+            str(run_dir / "activity.json"),
+            "--output",
+            str(run_dir / "report.md"),
+        ]
+    )
+
+    manifest = run_dir / "run.txt"
+    manifest.write_text(
+        "\n".join(
+            [
+                f"repo={args.repo}",
+                f"preset={args.preset}",
+                f"since={since.isoformat()}",
+                f"until={until.isoformat()}",
+                f"compare_previous={'false' if args.no_compare_previous else 'true'}",
+                f"activity={run_dir / 'activity.json'}",
+                f"summary={run_dir / 'summary.md'}",
+                f"report={run_dir / 'report.md'}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    print(f"Run directory: {run_dir}")
+    print(f"Activity JSON: {run_dir / 'activity.json'}")
+    print(f"Summary: {run_dir / 'summary.md'}")
+    print(f"Report: {run_dir / 'report.md'}")
+    print(f"Manifest: {manifest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/loong-monitor/scripts/run_monitor_cycle.py
+++ b/skills/loong-monitor/scripts/run_monitor_cycle.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Run loong-monitor in one step for weekly or monthly reporting."
+        description="Run loong-monitor in one step for rolling or calendar reporting."
     )
     parser.add_argument(
         "--repo",
@@ -22,9 +22,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--preset",
-        choices=["weekly", "monthly"],
+        choices=["weekly", "monthly", "calendar-week", "calendar-month"],
         required=True,
-        help="Reporting preset. weekly=last 7 days, monthly=last 30 days.",
+        help=(
+            "Reporting preset. "
+            "weekly=last 7 days, monthly=last 30 days, "
+            "calendar-week=from Monday of the containing ISO week to --until, "
+            "calendar-month=from the first day of the containing month to --until."
+        ),
     )
     parser.add_argument(
         "--until",
@@ -60,8 +65,14 @@ def parse_date(value: str) -> date:
 
 
 def compute_window(preset: str, until: date) -> tuple[date, date]:
-    days = 7 if preset == "weekly" else 30
-    since = until - timedelta(days=days - 1)
+    if preset == "weekly":
+        since = until - timedelta(days=6)
+    elif preset == "monthly":
+        since = until - timedelta(days=29)
+    elif preset == "calendar-week":
+        since = until - timedelta(days=until.weekday())
+    else:
+        since = until.replace(day=1)
     return since, until
 
 
@@ -80,6 +91,7 @@ def enrich_activity_json(activity_path: Path, preset: str, run_dir: Path) -> Non
     payload["run_metadata"] = {
         "preset": preset,
         "run_dir": str(run_dir),
+        "window_mode": "calendar" if preset.startswith("calendar-") else "rolling",
     }
     activity_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 

--- a/skills/loong-monitor/scripts/run_monitor_cycle.py
+++ b/skills/loong-monitor/scripts/run_monitor_cycle.py
@@ -22,13 +22,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--preset",
-        choices=["weekly", "monthly", "calendar-week", "calendar-month"],
+        choices=["weekly", "monthly", "quarter", "calendar-week", "calendar-month", "calendar-quarter"],
         required=True,
         help=(
             "Reporting preset. "
-            "weekly=last 7 days, monthly=last 30 days, "
+            "weekly=last 7 days, monthly=last 30 days, quarter=last 90 days, "
             "calendar-week=from Monday of the containing ISO week to --until, "
-            "calendar-month=from the first day of the containing month to --until."
+            "calendar-month=from the first day of the containing month to --until, "
+            "calendar-quarter=from the first day of the containing quarter to --until."
         ),
     )
     parser.add_argument(
@@ -69,10 +70,15 @@ def compute_window(preset: str, until: date) -> tuple[date, date]:
         since = until - timedelta(days=6)
     elif preset == "monthly":
         since = until - timedelta(days=29)
+    elif preset == "quarter":
+        since = until - timedelta(days=89)
     elif preset == "calendar-week":
         since = until - timedelta(days=until.weekday())
-    else:
+    elif preset == "calendar-month":
         since = until.replace(day=1)
+    else:
+        quarter_start_month = ((until.month - 1) // 3) * 3 + 1
+        since = until.replace(month=quarter_start_month, day=1)
     return since, until
 
 

--- a/skills/loong-monitor/scripts/run_monitor_cycle.py
+++ b/skills/loong-monitor/scripts/run_monitor_cycle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import subprocess
 import sys
 from datetime import date, datetime, timedelta, timezone
@@ -58,6 +59,13 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Disable previous-window comparison for this run.",
     )
+    parser.add_argument(
+        "--copy-to",
+        help=(
+            "Optional publish root. When set, the run directory is copied to "
+            "<copy-to>/<repo_slug>/<run-name>/ and latest views are refreshed."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -92,6 +100,29 @@ def run_command(command: list[str]) -> None:
         raise SystemExit(completed.returncode)
 
 
+def reset_dir(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def publish_run(run_dir: Path, repo_slug: str, preset: str, copy_root: str) -> dict[str, str]:
+    publish_root = Path(copy_root) / repo_slug
+    published_dir = publish_root / run_dir.name
+    latest_preset_dir = publish_root / f"latest-{preset}"
+    latest_dir = publish_root / "latest"
+
+    for target in (published_dir, latest_preset_dir, latest_dir):
+        reset_dir(target)
+        shutil.copytree(run_dir, target)
+
+    return {
+        "published_dir": str(published_dir),
+        "latest_preset_dir": str(latest_preset_dir),
+        "latest_dir": str(latest_dir),
+    }
+
+
 def enrich_activity_json(activity_path: Path, preset: str, run_dir: Path) -> None:
     payload = json.loads(activity_path.read_text(encoding="utf-8"))
     payload["run_metadata"] = {
@@ -106,10 +137,11 @@ def main() -> int:
     args = parse_args()
     until = parse_date(args.until) if args.until else datetime.now(timezone.utc).date()
     since, until = compute_window(args.preset, until)
+    repo_slug = slug_repo(args.repo)
 
     run_dir = (
         Path(args.output_root)
-        / slug_repo(args.repo)
+        / repo_slug
         / f"{args.preset}-{since.isoformat()}_to_{until.isoformat()}"
     )
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -150,29 +182,50 @@ def main() -> int:
         ]
     )
 
-    manifest = run_dir / "run.txt"
-    manifest.write_text(
-        "\n".join(
+    publish_info: dict[str, str] = {}
+    if args.copy_to:
+        publish_info = publish_run(run_dir, repo_slug, args.preset, args.copy_to)
+
+    manifest_lines = [
+        f"repo={args.repo}",
+        f"preset={args.preset}",
+        f"since={since.isoformat()}",
+        f"until={until.isoformat()}",
+        f"compare_previous={'false' if args.no_compare_previous else 'true'}",
+        f"activity={run_dir / 'activity.json'}",
+        f"summary={run_dir / 'summary.md'}",
+        f"report={run_dir / 'report.md'}",
+    ]
+    if publish_info:
+        manifest_lines.extend(
             [
-                f"repo={args.repo}",
-                f"preset={args.preset}",
-                f"since={since.isoformat()}",
-                f"until={until.isoformat()}",
-                f"compare_previous={'false' if args.no_compare_previous else 'true'}",
-                f"activity={run_dir / 'activity.json'}",
-                f"summary={run_dir / 'summary.md'}",
-                f"report={run_dir / 'report.md'}",
+                f"published_dir={publish_info['published_dir']}",
+                f"latest_preset_dir={publish_info['latest_preset_dir']}",
+                f"latest_dir={publish_info['latest_dir']}",
             ]
         )
-        + "\n",
-        encoding="utf-8",
-    )
+
+    manifest = run_dir / "run.txt"
+    manifest.write_text("\n".join(manifest_lines) + "\n", encoding="utf-8")
+
+    if publish_info:
+        for target in (
+            Path(publish_info["published_dir"]),
+            Path(publish_info["latest_preset_dir"]),
+            Path(publish_info["latest_dir"]),
+        ):
+            manifest_target = target / "run.txt"
+            manifest_target.write_text("\n".join(manifest_lines) + "\n", encoding="utf-8")
 
     print(f"Run directory: {run_dir}")
     print(f"Activity JSON: {run_dir / 'activity.json'}")
     print(f"Summary: {run_dir / 'summary.md'}")
     print(f"Report: {run_dir / 'report.md'}")
     print(f"Manifest: {manifest}")
+    if publish_info:
+        print(f"Published directory: {publish_info['published_dir']}")
+        print(f"Latest preset directory: {publish_info['latest_preset_dir']}")
+        print(f"Latest directory: {publish_info['latest_dir']}")
     return 0
 
 

--- a/skills/loong-monitor/scripts/run_monitor_cycle.py
+++ b/skills/loong-monitor/scripts/run_monitor_cycle.py
@@ -66,6 +66,13 @@ def parse_args() -> argparse.Namespace:
             "<copy-to>/<repo_slug>/<run-name>/ and latest views are refreshed."
         ),
     )
+    parser.add_argument(
+        "--index-file",
+        help=(
+            "Optional Markdown index path for published runs. "
+            "Defaults to <copy-to>/<repo_slug>/index.md when --copy-to is set."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -117,10 +124,70 @@ def publish_run(run_dir: Path, repo_slug: str, preset: str, copy_root: str) -> d
         shutil.copytree(run_dir, target)
 
     return {
+        "publish_root": str(publish_root),
         "published_dir": str(published_dir),
         "latest_preset_dir": str(latest_preset_dir),
         "latest_dir": str(latest_dir),
     }
+
+
+def write_publish_index(
+    publish_root: Path,
+    repo: str,
+    index_path: Path,
+) -> None:
+    publish_root.mkdir(parents=True, exist_ok=True)
+    run_dirs = sorted(
+        [
+            path for path in publish_root.iterdir()
+            if path.is_dir() and not path.name.startswith("latest")
+        ],
+        key=lambda path: path.name,
+        reverse=True,
+    )
+    latest_dirs = sorted(
+        [
+            path for path in publish_root.iterdir()
+            if path.is_dir() and path.name.startswith("latest")
+        ],
+        key=lambda path: path.name,
+    )
+
+    lines = [
+        "# Loong Monitor Published Index",
+        "",
+        f"- Repository slug root: `{publish_root}`",
+        f"- Source repository: `{repo}`",
+        f"- Updated at: {datetime.now(timezone.utc).isoformat()}",
+        "",
+        "## Latest Views",
+        "",
+    ]
+
+    if latest_dirs:
+        for path in latest_dirs:
+            report = path / "report.md"
+            manifest = path / "run.txt"
+            lines.append(
+                f"- `{path.name}`: report `{report}`, manifest `{manifest}`"
+            )
+    else:
+        lines.append("- No latest views published yet.")
+
+    lines.extend(["", "## Recent Published Runs", ""])
+    if run_dirs:
+        for path in run_dirs[:20]:
+            report = path / "report.md"
+            summary = path / "summary.md"
+            manifest = path / "run.txt"
+            lines.append(
+                f"- `{path.name}`: report `{report}`, summary `{summary}`, manifest `{manifest}`"
+            )
+    else:
+        lines.append("- No published runs found.")
+
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def enrich_activity_json(activity_path: Path, preset: str, run_dir: Path) -> None:
@@ -185,6 +252,13 @@ def main() -> int:
     publish_info: dict[str, str] = {}
     if args.copy_to:
         publish_info = publish_run(run_dir, repo_slug, args.preset, args.copy_to)
+        index_path = (
+            Path(args.index_file)
+            if args.index_file
+            else Path(publish_info["publish_root"]) / "index.md"
+        )
+        write_publish_index(Path(publish_info["publish_root"]), args.repo, index_path)
+        publish_info["index_file"] = str(index_path)
 
     manifest_lines = [
         f"repo={args.repo}",
@@ -199,9 +273,11 @@ def main() -> int:
     if publish_info:
         manifest_lines.extend(
             [
+                f"publish_root={publish_info['publish_root']}",
                 f"published_dir={publish_info['published_dir']}",
                 f"latest_preset_dir={publish_info['latest_preset_dir']}",
                 f"latest_dir={publish_info['latest_dir']}",
+                f"index_file={publish_info['index_file']}",
             ]
         )
 
@@ -226,6 +302,7 @@ def main() -> int:
         print(f"Published directory: {publish_info['published_dir']}")
         print(f"Latest preset directory: {publish_info['latest_preset_dir']}")
         print(f"Latest directory: {publish_info['latest_dir']}")
+        print(f"Index file: {publish_info['index_file']}")
     return 0
 
 


### PR DESCRIPTION
## Summary

- bootstrap the repository layout for team-maintained skills
- add the first skill, `loong-monitor`, for evidence-backed monitoring of `loongclaw-ai/loongclaw` activity
- include a GitHub activity collector, previous-window comparison support, confidence scoring, and a full Markdown report generator
- add one-command rolling and calendar presets for weekly, monthly, and quarterly monitoring runs
- add fixed-directory publishing via `--copy-to`, including per-run, latest-per-preset, latest, and published index views
- add retry handling for transient GitHub CLI/API timeout failures during collection

## Validation

- `python3 /Users/chum/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/chum/skills/skills/loong-monitor`
- `python3 -m py_compile skills/loong-monitor/scripts/collect_repo_activity.py skills/loong-monitor/scripts/generate_report.py skills/loong-monitor/scripts/run_monitor_cycle.py`
- `python3 skills/loong-monitor/scripts/collect_repo_activity.py --repo loongclaw-ai/loongclaw --days 30 --limit 20 --detail-limit 10 --compare-previous --output /tmp/loong-monitor-deep`
- `python3 skills/loong-monitor/scripts/generate_report.py --activity /tmp/loong-monitor-deep/activity.json --output /tmp/loong-monitor-deep/report.md`
- `python3 skills/loong-monitor/scripts/run_monitor_cycle.py --preset weekly --repo loongclaw-ai/loongclaw --output-root /tmp/loong-monitor-presets --limit 15 --detail-limit 8`
- `python3 skills/loong-monitor/scripts/run_monitor_cycle.py --preset calendar-week --repo loongclaw-ai/loongclaw --output-root /tmp/loong-monitor-presets --limit 12 --detail-limit 6`
- `python3 skills/loong-monitor/scripts/run_monitor_cycle.py --preset calendar-month --repo loongclaw-ai/loongclaw --until 2026-03-31 --output-root /tmp/loong-monitor-presets --limit 12 --detail-limit 6`
- `python3 skills/loong-monitor/scripts/run_monitor_cycle.py --preset quarter --repo loongclaw-ai/loongclaw --output-root /tmp/loong-monitor-presets --limit 10 --detail-limit 5`
- `python3 skills/loong-monitor/scripts/run_monitor_cycle.py --preset calendar-quarter --repo loongclaw-ai/loongclaw --until 2026-03-31 --output-root /tmp/loong-monitor-presets --limit 10 --detail-limit 5`
- `python3 skills/loong-monitor/scripts/run_monitor_cycle.py --preset weekly --repo loongclaw-ai/loongclaw --output-root /tmp/loong-monitor-runs --copy-to /tmp/loong-monitor-published --limit 8 --detail-limit 4`

Closes #1
